### PR TITLE
Create issue template to report bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/prism-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/prism-bug-report.md
@@ -1,0 +1,29 @@
+---
+name: Prism bug report
+about: Create a report to help us improve Prism
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/prism-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/prism-bug-report.md
@@ -1,6 +1,6 @@
 ---
-name: Prism bug report
-about: Create a report to help us improve Prism
+name: Bug report
+about: Help us improve Prism by reporting a bug
 
 ---
 


### PR DESCRIPTION
I added the same questions as in Primer CSS. I think it'll be more readable for the team as they are already familiar with the template.