### PR TITLE
Fix the issue with popping colors

### DIFF
--- a/src/global-state.tsx
+++ b/src/global-state.tsx
@@ -262,7 +262,13 @@ const machine = Machine<MachineContext, MachineEvent>({
     POP_COLOR: {
       target: "debouncing",
       actions: assign((context, event) => {
-        context.palettes[event.paletteId].scales[event.scaleId].colors.pop();
+        const colors = context.palettes[event.paletteId].scales[event.scaleId].colors;
+
+        if (colors.length > 1) {
+          colors.pop();
+        }
+
+        return colors;
       }),
     },
     DELETE_COLOR: {

--- a/src/pages/scale.tsx
+++ b/src/pages/scale.tsx
@@ -104,6 +104,7 @@ export function Scale({
               icon={DashIcon}
               aria-label="Remove color from end of scale"
               onClick={() => send({ type: "POP_COLOR", paletteId, scaleId })}
+              disabled={scale.colors.length === 1}
             />
             <IconButton
               icon={PlusIcon}


### PR DESCRIPTION
I've added check that if colors length is 1, then we disable our button
to let user know that we're not able to remove last color from the
scale and I also updated state machine to ignore all requests to pop
last color from the scale.

Fixes the issue #10