### PR TITLE
Fix for selected index when switching scale

### DIFF
--- a/src/pages/scale.tsx
+++ b/src/pages/scale.tsx
@@ -40,7 +40,7 @@ export function Scale({
   }
 
   let focusedHex: string | undefined
-  const index = Number(selectedIndex) > scale.colors.length - 1 ? String(scale.colors.length - 1) : selectedIndex
+  const index = String(Math.min(Number(selectedIndex), scale.colors.length - 1))
 
   try {
     const focusedColor = index ? getColor(palette.curves, scale, parseInt(index, 10)) : undefined


### PR DESCRIPTION
This PR fixes the issue #19.

I've updated the code to check if our selected index is greater than our color scale, and if it is, then we just select the last color from the scale, but if we switch back, it will be the same selected color.

@rafaeltab Could you test it and let me know if everything works as expected? 😊 
