### PR TITLE
Add delete button on palette card

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -119,7 +119,7 @@ export function Index(props: RouteComponentProps) {
                 </Box>
                 <Text
                   sx={{
-                    lineHeight: '1',
+                    lineHeight: '1.2',
                     textOverflow: 'ellipsis',
                     width: '80%',
                     overflow: 'hidden',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -59,7 +59,7 @@ export function Index(props: RouteComponentProps) {
           }}
         >
           {Object.values(state.context.palettes).map(palette => (
-            <li key={palette.id}>
+            <li key={palette.id} style={{ position: 'relative' }}>
               <Box
                 as={Link}
                 to={`${routePrefix}/local/${palette.id}`}
@@ -67,6 +67,7 @@ export function Index(props: RouteComponentProps) {
                   display: 'grid',
                   gap: 3,
                   p: 3,
+                  pb: 3,
                   textDecoration: 'none',
                   borderRadius: 2,
                   // border: "1px solid",
@@ -115,30 +116,32 @@ export function Index(props: RouteComponentProps) {
                     </Box>
                   ))}
                 </Box>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    justifyContent: 'space-between',
-                    gap: 2,
-                  }}
-                >
-                  <Text sx={{ lineHeight: '1' }}>{palette.name}</Text>
-                  <IconButton
-                    aria-label='Delete Palette'
-                    icon={TrashIcon}
-                    onClick={(e: PointerEvent) => {
-                      send({ type: 'DELETE_PALETTE', paletteId: palette.id })
-                      e.preventDefault()
-                    }}
-                    sx={{
-                      color: readableColor(palette.backgroundColor),
-                      backgroundColor: palette.backgroundColor,
-                      borderColor: mix(readableColor(palette.backgroundColor), palette.backgroundColor, 0.75),
-                    }}
-                  >Delete alette</IconButton>
-                </Box>
+                <Text sx={{ lineHeight: '1' }}>{palette.name}</Text>
               </Box>
+              <IconButton
+                  aria-label='Delete Palette'
+                  icon={TrashIcon}
+                  onClick={() => {
+                    send({ type: 'DELETE_PALETTE', paletteId: palette.id })
+                  }}
+                  sx={{
+                    color: readableColor(palette.backgroundColor),
+                    backgroundColor: palette.backgroundColor,
+                    borderColor: mix(
+                      readableColor(palette.backgroundColor),
+                      palette.backgroundColor,
+                      0.75),
+                    position: 'absolute',
+                    right: 3,
+                    bottom: 2,
+                    '&:hover:not([disabled])': {
+                      backgroundColor: mix(
+                        readableColor(palette.backgroundColor),
+                        palette.backgroundColor,
+                        0.85),
+                    }
+                  }}
+                >Delete alette</IconButton>
             </li>
           ))}
         </Box>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -55,7 +55,8 @@ export function Index(props: RouteComponentProps) {
             listStyle: 'none',
             display: 'grid',
             gap: 3,
-            gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))'
+            gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+            gridTemplateRows: '230px'
           }}
         >
           {Object.values(state.context.palettes).map(palette => (
@@ -63,18 +64,18 @@ export function Index(props: RouteComponentProps) {
               <Box
                 as={Link}
                 to={`${routePrefix}/local/${palette.id}`}
+                p={3}
                 sx={{
                   display: 'grid',
                   gap: 3,
-                  p: 3,
-                  pb: 3,
                   textDecoration: 'none',
                   borderRadius: 2,
                   // border: "1px solid",
                   // borderColor: "border.default",
                   overflow: 'hidden',
                   color: readableColor(palette.backgroundColor),
-                  backgroundColor: palette.backgroundColor
+                  backgroundColor: palette.backgroundColor,
+                  height:'100%'
                 }}
               >
                 <Box
@@ -116,7 +117,13 @@ export function Index(props: RouteComponentProps) {
                     </Box>
                   ))}
                 </Box>
-                <Text sx={{ lineHeight: '1' }}>{palette.name}</Text>
+                <Text sx={{
+                  lineHeight: '1',
+                  textOverflow: 'ellipsis',
+                  width: '80%',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap'
+                }}>{palette.name}</Text>
               </Box>
               <IconButton
                   aria-label='Delete Palette'
@@ -141,7 +148,7 @@ export function Index(props: RouteComponentProps) {
                         0.85),
                     }
                   }}
-                >Delete alette</IconButton>
+                />
             </li>
           ))}
         </Box>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import {LinkExternalIcon, MarkGithubIcon, PlusIcon, TrashIcon} from '@primer/octicons-react'
 import {Box, Button, Heading, IconButton, Label, Link as PrimerLink, StyledOcticon, Text} from '@primer/react'
 import {Link, RouteComponentProps} from '@reach/router'
-import {readableColor} from 'color2k'
+import {mix, readableColor} from 'color2k'
 import React from 'react'
 import {routePrefix} from '../constants'
 import {useGlobalState} from '../global-state'
@@ -125,13 +125,18 @@ export function Index(props: RouteComponentProps) {
                 >
                   <Text sx={{ lineHeight: '1' }}>{palette.name}</Text>
                   <IconButton
-                    aria-label='Delete palette'
+                    aria-label='Delete Palette'
                     icon={TrashIcon}
                     onClick={(e: PointerEvent) => {
                       send({ type: 'DELETE_PALETTE', paletteId: palette.id })
                       e.preventDefault()
                     }}
-                  />
+                    sx={{
+                      color: readableColor(palette.backgroundColor),
+                      backgroundColor: palette.backgroundColor,
+                      borderColor: mix(readableColor(palette.backgroundColor), palette.backgroundColor, 0.75),
+                    }}
+                  >Delete alette</IconButton>
                 </Box>
               </Box>
             </li>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -139,7 +139,7 @@ export function Index(props: RouteComponentProps) {
                 </Text>
               </Box>
               <IconButton
-                aria-label="Delete Palette"
+                aria-label="Delete palette"
                 icon={TrashIcon}
                 onClick={() => {
                   send({type: 'DELETE_PALETTE', paletteId: palette.id})

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import {
   LinkExternalIcon,
   MarkGithubIcon,
   PlusIcon,
+  TrashIcon,
 } from "@primer/octicons-react";
 import {
   Box,
@@ -95,7 +96,7 @@ export function Index(props: RouteComponentProps) {
                     overflow: "hidden",
                     display: "flex",
                     height: 160,
-                    gap: 2,
+                    gap: 3,
                   }}
                 >
                   {Object.values(palette.scales).map(scale => (
@@ -127,7 +128,21 @@ export function Index(props: RouteComponentProps) {
                     </Box>
                   ))}
                 </Box>
-                <Text sx={{ lineHeight: "1" }}>{palette.name}</Text>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    justifyContent: "space-between",
+                    gap: 2,
+                  }}
+                >
+                  <Text sx={{ lineHeight: "1" }}>{palette.name}</Text>
+                  <IconButton
+                    aria-label="Delete palette"
+                    icon={TrashIcon}
+                    onClick={() => send({ type: "DELETE_PALETTE", paletteId: palette.id })}
+                  />
+                </Box>
               </Box>
             </li>
           ))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -140,7 +140,10 @@ export function Index(props: RouteComponentProps) {
                   <IconButton
                     aria-label="Delete palette"
                     icon={TrashIcon}
-                    onClick={() => send({ type: "DELETE_PALETTE", paletteId: palette.id })}
+                    onClick={(e: PointerEvent) => {
+                      send({ type: "DELETE_PALETTE", paletteId: palette.id })
+                      e.preventDefault()
+                    }}
                   />
                 </Box>
               </Box>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,24 +1,11 @@
-import {
-  LinkExternalIcon,
-  MarkGithubIcon,
-  PlusIcon,
-  TrashIcon
-} from "@primer/octicons-react";
-import {
-  Box,
-  Button,
-  Heading,
-  IconButton,
-  Label,
-  Link as PrimerLink,
-  StyledOcticon,
-  Text
-} from "@primer/react";
-import { Link, RouteComponentProps } from "@reach/router";
-import { readableColor } from "color2k";
-import { routePrefix } from "../constants";
-import { useGlobalState } from "../global-state";
-import { colorToHex, getColor } from "../utils";
+import {LinkExternalIcon, MarkGithubIcon, PlusIcon, TrashIcon} from '@primer/octicons-react'
+import {Box, Button, Heading, IconButton, Label, Link as PrimerLink, StyledOcticon, Text} from '@primer/react'
+import {Link, RouteComponentProps} from '@reach/router'
+import {readableColor} from 'color2k'
+import React from 'react'
+import {routePrefix} from '../constants'
+import {useGlobalState} from '../global-state'
+import {colorToHex, getColor} from '../utils'
 
 export function Index(props: RouteComponentProps) {
   const [state, send] = useGlobalState()
@@ -130,18 +117,18 @@ export function Index(props: RouteComponentProps) {
                 </Box>
                 <Box
                   sx={{
-                    display: "flex",
-                    alignItems: "flex-start",
-                    justifyContent: "space-between",
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    justifyContent: 'space-between',
                     gap: 2,
                   }}
                 >
-                  <Text sx={{ lineHeight: "1" }}>{palette.name}</Text>
+                  <Text sx={{ lineHeight: '1' }}>{palette.name}</Text>
                   <IconButton
-                    aria-label="Delete palette"
+                    aria-label='Delete palette'
                     icon={TrashIcon}
                     onClick={(e: PointerEvent) => {
-                      send({ type: "DELETE_PALETTE", paletteId: palette.id })
+                      send({ type: 'DELETE_PALETTE', paletteId: palette.id })
                       e.preventDefault()
                     }}
                   />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ export function Index(props: RouteComponentProps) {
           }}
         >
           {Object.values(state.context.palettes).map(palette => (
-            <li key={palette.id} style={{ position: 'relative' }}>
+            <li key={palette.id} style={{position: 'relative'}}>
               <Box
                 as={Link}
                 to={`${routePrefix}/local/${palette.id}`}
@@ -75,7 +75,7 @@ export function Index(props: RouteComponentProps) {
                   overflow: 'hidden',
                   color: readableColor(palette.backgroundColor),
                   backgroundColor: palette.backgroundColor,
-                  height:'100%'
+                  height: '100%'
                 }}
               >
                 <Box
@@ -84,7 +84,7 @@ export function Index(props: RouteComponentProps) {
                     overflow: 'hidden',
                     display: 'flex',
                     height: 160,
-                    gap: 3,
+                    gap: 3
                   }}
                 >
                   {Object.values(palette.scales).map(scale => (
@@ -117,38 +117,36 @@ export function Index(props: RouteComponentProps) {
                     </Box>
                   ))}
                 </Box>
-                <Text sx={{
-                  lineHeight: '1',
-                  textOverflow: 'ellipsis',
-                  width: '80%',
-                  overflow: 'hidden',
-                  whiteSpace: 'nowrap'
-                }}>{palette.name}</Text>
+                <Text
+                  sx={{
+                    lineHeight: '1',
+                    textOverflow: 'ellipsis',
+                    width: '80%',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap'
+                  }}
+                >
+                  {palette.name}
+                </Text>
               </Box>
               <IconButton
-                  aria-label='Delete Palette'
-                  icon={TrashIcon}
-                  onClick={() => {
-                    send({ type: 'DELETE_PALETTE', paletteId: palette.id })
-                  }}
-                  sx={{
-                    color: readableColor(palette.backgroundColor),
-                    backgroundColor: palette.backgroundColor,
-                    borderColor: mix(
-                      readableColor(palette.backgroundColor),
-                      palette.backgroundColor,
-                      0.75),
-                    position: 'absolute',
-                    right: 3,
-                    bottom: 2,
-                    '&:hover:not([disabled])': {
-                      backgroundColor: mix(
-                        readableColor(palette.backgroundColor),
-                        palette.backgroundColor,
-                        0.85),
-                    }
-                  }}
-                />
+                aria-label="Delete Palette"
+                icon={TrashIcon}
+                onClick={() => {
+                  send({type: 'DELETE_PALETTE', paletteId: palette.id})
+                }}
+                sx={{
+                  color: readableColor(palette.backgroundColor),
+                  backgroundColor: palette.backgroundColor,
+                  borderColor: mix(readableColor(palette.backgroundColor), palette.backgroundColor, 0.75),
+                  position: 'absolute',
+                  right: 3,
+                  bottom: 2,
+                  '&:hover:not([disabled])': {
+                    backgroundColor: mix(readableColor(palette.backgroundColor), palette.backgroundColor, 0.85)
+                  }
+                }}
+              />
             </li>
           ))}
         </Box>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,17 @@
 import {LinkExternalIcon, MarkGithubIcon, PlusIcon, TrashIcon} from '@primer/octicons-react'
-import {Box, Button, Heading, IconButton, Label, Link as PrimerLink, StyledOcticon, Text} from '@primer/react'
+import {
+  Box,
+  Button,
+  Heading,
+  IconButton as PrimerIconButton,
+  Label,
+  Link as PrimerLink,
+  StyledOcticon,
+  Text
+} from '@primer/react'
 import {Link, RouteComponentProps} from '@reach/router'
 import {mix, readableColor} from 'color2k'
-import React from 'react'
+import {IconButton} from '../components/button'
 import {routePrefix} from '../constants'
 import {useGlobalState} from '../global-state'
 import {colorToHex, getColor} from '../utils'
@@ -38,7 +47,7 @@ export function Index(props: RouteComponentProps) {
             GitHub
             <StyledOcticon icon={LinkExternalIcon} sx={{marginLeft: 1}} />
           </PrimerLink>
-          <IconButton
+          <PrimerIconButton
             aria-label="Create new palette"
             icon={PlusIcon}
             onClick={() => send('CREATE_PALETTE')}
@@ -119,7 +128,7 @@ export function Index(props: RouteComponentProps) {
                 </Box>
                 <Text
                   sx={{
-                    lineHeight: '1.2',
+                    lineHeight: '24px',
                     textOverflow: 'ellipsis',
                     width: '80%',
                     overflow: 'hidden',
@@ -136,15 +145,22 @@ export function Index(props: RouteComponentProps) {
                   send({type: 'DELETE_PALETTE', paletteId: palette.id})
                 }}
                 sx={{
-                  color: readableColor(palette.backgroundColor),
-                  backgroundColor: palette.backgroundColor,
-                  borderColor: mix(readableColor(palette.backgroundColor), palette.backgroundColor, 0.75),
+                  '--color-text': readableColor(palette.backgroundColor),
+                  '--color-background': palette.backgroundColor,
+                  '--color-background-secondary': mix(
+                    readableColor(palette.backgroundColor),
+                    palette.backgroundColor,
+                    0.9
+                  ),
+                  '--color-background-secondary-hover': mix(
+                    readableColor(palette.backgroundColor),
+                    palette.backgroundColor,
+                    0.85
+                  ),
+                  '--color-border': mix(readableColor(palette.backgroundColor), palette.backgroundColor, 0.75),
                   position: 'absolute',
                   right: 3,
-                  bottom: 2,
-                  '&:hover:not([disabled])': {
-                    backgroundColor: mix(readableColor(palette.backgroundColor), palette.backgroundColor, 0.85)
-                  }
+                  bottom: '12px'
                 }}
               />
             </li>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,7 +56,7 @@ export function Index(props: RouteComponentProps) {
             display: 'grid',
             gap: 3,
             gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
-            gridTemplateRows: '230px'
+            lineClamp: 1
           }}
         >
           {Object.values(state.context.palettes).map(palette => (


### PR DESCRIPTION
Fixes #20 

<img width="1165" alt="Screenshot 2022-06-22 at 7 11 01 AM" src="https://user-images.githubusercontent.com/25580776/174948517-be03e651-6db8-417e-9e94-71af9fdb2c50.png">



## CHANGELOG
### Added
- Delete icon button on the palette card.
- Palette card title now truncates.
- All cards persist same height.

