### PR TITLE
Add Prettier/build check as a CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ensure-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Prettier
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Ensure build succeeds
+        run: yarn build:preview
+
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Prettier
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run prettier
+        run: yarn lint
+
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Prettier
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run prettier
+        run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,44 +7,17 @@ on:
       - main
 
 jobs:
-  ensure-build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Prettier
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Run Prettier
+        run: yarn lint
       - name: Ensure build succeeds
         run: yarn build:preview
-
-  eslint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Prettier
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Run prettier
-        run: yarn lint
-
-  prettier:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Prettier
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Run prettier
-        run: yarn lint


### PR DESCRIPTION
Noticed that Prettier wasn't ran in CI. This will prevent unformatted code. I tried to model the action on `primer`'s GA config.