### PR TITLE
Disable Delete Color Button when we have only one color

### DIFF
--- a/src/components/color.tsx
+++ b/src/components/color.tsx
@@ -132,6 +132,7 @@ export function Color({paletteId = '', scaleId = '', index = ''}: {paletteId: st
               index: parseInt(index)
             })
           }
+          disabled={scale.colors.length === 1}
         >
           Delete color
         </Button>

--- a/src/global-state.tsx
+++ b/src/global-state.tsx
@@ -267,7 +267,13 @@ const machine = Machine<MachineContext, MachineEvent>({
     DELETE_COLOR: {
       target: 'debouncing',
       actions: assign((context, event) => {
-        context.palettes[event.paletteId].scales[event.scaleId].colors.splice(event.index, 1)
+        const colors = context.palettes[event.paletteId].scales[event.scaleId].colors
+
+        if (colors.length > 1) {
+          colors.splice(event.index, 1)
+        }
+
+        return colors
       })
     },
     CHANGE_COLOR_VALUE: {


### PR DESCRIPTION
This PR closes the issue #35.

The solution is to disabled "Delete Color" button when we have only one color in the scale.