### PR TITLE
Add ability to apply easing functions to curves

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@xstate/immer": "^0.2.0",
     "@xstate/inspect": "^0.4.1",
     "@xstate/react": "^1.3.2",
+    "bezier-easing": "^2.1.0",
     "color2k": "^1.2.4",
     "copy-to-clipboard": "^3.3.1",
     "d3-scale": "^3.3.0",

--- a/src/components/apply-easing-function.tsx
+++ b/src/components/apply-easing-function.tsx
@@ -1,0 +1,74 @@
+import bezier from 'bezier-easing'
+import {capitalize, kebabCase} from 'lodash'
+import * as React from 'react'
+import {easingFunctions, Easing} from '../easings'
+import {Button} from './button'
+import {Select} from './select'
+import {SidebarPanel} from './sidebar-panel'
+import {VStack} from './stack'
+
+type CurveKey = keyof typeof easingFunctions
+
+type ApplyEasingFunctionProps = {
+  onApply: (easingFunction: bezier.EasingFunction) => void
+}
+
+export function ApplyEasingFunction({onApply}: ApplyEasingFunctionProps) {
+  const [curveKey, setCurveKey] = React.useState<CurveKey>('linear')
+  const baseCurve = easingFunctions[curveKey]
+  const [easing, setEasing] = React.useState<Easing>('inOut')
+
+  const easingOptions = typeof baseCurve === 'function' ? [] : Object.keys(baseCurve)
+  const easingFunction = typeof baseCurve === 'function' ? baseCurve : baseCurve[easing]
+
+  function applyEasingFunction() {
+    onApply(easingFunction)
+  }
+
+  return (
+    <SidebarPanel title="Apply easing function">
+      <VStack spacing={16}>
+        <VStack spacing={4}>
+          <label htmlFor="base-curve" style={{fontSize: 14}}>
+            Base curve
+          </label>
+
+          <Select id="base-curve" value={curveKey ?? ''} onChange={e => setCurveKey(e.target.value as CurveKey)}>
+            {Object.keys(easingFunctions).map(key => (
+              <option value={key} key={key}>
+                {capitalize(key)}
+              </option>
+            ))}
+          </Select>
+        </VStack>
+
+        <VStack spacing={4}>
+          <label htmlFor="easing" style={{fontSize: 14}}>
+            Easing
+          </label>
+
+          <Select
+            id="easing"
+            disabled={easingOptions.length === 0}
+            value={easing ?? ''}
+            onChange={e => setEasing(e.target.value as Easing)}
+          >
+            {easingOptions.length === 0 ? (
+              <option>—</option>
+            ) : (
+              easingOptions.map(easing => (
+                <option value={easing} key={easing}>
+                  {capitalize(kebabCase(easing))}
+                </option>
+              ))
+            )}
+          </Select>
+        </VStack>
+
+        <Button onClick={applyEasingFunction} disabled={!easingFunction}>
+          Apply easing
+        </Button>
+      </VStack>
+    </SidebarPanel>
+  )
+}

--- a/src/easings.ts
+++ b/src/easings.ts
@@ -1,0 +1,58 @@
+import bezier, {EasingFunction} from 'bezier-easing'
+
+export const easings = ['in', 'out', 'inOut'] as const
+export type Easing = typeof easings[number]
+
+type EasingFunctionsDefinition = {
+  [name: string]:
+    | EasingFunction
+    | {
+        [easing in Easing]: EasingFunction
+      }
+}
+
+export const easingFunctions: EasingFunctionsDefinition = {
+  linear: bezier(0.5, 0.5, 0.5, 0.5),
+
+  quadratic: {
+    inOut: bezier(0.455, 0.03, 0.515, 0.955),
+    in: bezier(0.55, 0.085, 0.68, 0.53),
+    out: bezier(0.25, 0.46, 0.45, 0.94)
+  },
+
+  cubic: {
+    inOut: bezier(0.645, 0.045, 0.355, 1),
+    in: bezier(0.55, 0.055, 0.675, 0.19),
+    out: bezier(0.215, 0.61, 0.355, 1)
+  },
+
+  quartic: {
+    inOut: bezier(0.77, 0, 0.175, 1),
+    in: bezier(0.895, 0.03, 0.685, 0.22),
+    out: bezier(0.165, 0.84, 0.44, 1)
+  },
+
+  quintic: {
+    inOut: bezier(0.86, 0, 0.07, 1),
+    in: bezier(0.755, 0.05, 0.855, 0.06),
+    out: bezier(0.23, 1, 0.32, 1)
+  },
+
+  sine: {
+    inOut: bezier(0.445, 0.05, 0.55, 0.95),
+    in: bezier(0.47, 0, 0.745, 0.715),
+    out: bezier(0.39, 0.575, 0.565, 1)
+  },
+
+  circular: {
+    inOut: bezier(0.785, 0.135, 0.15, 0.86),
+    in: bezier(0.6, 0.04, 0.98, 0.335),
+    out: bezier(0.075, 0.82, 0.165, 1)
+  },
+
+  exponential: {
+    inOut: bezier(1, 0, 0, 1),
+    in: bezier(0.95, 0.05, 0.795, 0.035),
+    out: bezier(0.19, 1, 0.22, 1)
+  }
+}

--- a/src/global-state.tsx
+++ b/src/global-state.tsx
@@ -1,6 +1,7 @@
 import {navigate} from '@reach/router'
 import {assign} from '@xstate/immer'
 import {useInterpret, useService} from '@xstate/react'
+import bezier from 'bezier-easing'
 import {isArray, keyBy} from 'lodash-es'
 import React from 'react'
 import {v4 as uniqueId} from 'uuid'
@@ -8,7 +9,7 @@ import {interpret, Machine} from 'xstate'
 import cssColorNames from './css-color-names.json'
 import exampleScales from './example-scales.json'
 import {Color, Curve, Palette, Scale} from './types'
-import {getColor, hexToColor, randomIntegerInRange} from './utils'
+import {getColor, hexToColor, randomIntegerInRange, lerp} from './utils'
 import {routePrefix} from './constants'
 
 const GLOBAL_STATE_KEY = 'global_state'
@@ -123,6 +124,12 @@ type MachineEvent =
       paletteId: string
       scaleId: string
       colors: Color[]
+    }
+  | {
+      type: 'APPLY_EASING_FUNCTION'
+      paletteId: string
+      curveId: string
+      easingFunction: bezier.EasingFunction
     }
   | {type: 'UNDO'}
   | {type: 'REDO'}
@@ -375,6 +382,24 @@ const machine = Machine<MachineContext, MachineEvent>({
       target: 'debouncing',
       actions: assign((context, event) => {
         context.palettes[event.paletteId].scales[event.scaleId].colors = event.colors
+      })
+    },
+    APPLY_EASING_FUNCTION: {
+      target: 'debouncing',
+      actions: assign((context, event) => {
+        const {paletteId, curveId, easingFunction} = event
+        const curve = context.palettes[paletteId].curves[curveId]
+
+        const startingPoint = curve.values[0]
+        const endingPoint = curve.values[curve.values.length - 1]
+
+        if (startingPoint == null || endingPoint == null) return
+
+        curve.values = curve.values.map((_, index) => {
+          const t = index / (curve.values.length - 1)
+          const newValue = lerp(startingPoint, endingPoint, easingFunction(t))
+          return Math.round(newValue * 10) / 10
+        })
       })
     }
   },

--- a/src/pages/curve.tsx
+++ b/src/pages/curve.tsx
@@ -1,5 +1,6 @@
 import {Link, navigate, RouteComponentProps} from '@reach/router'
 import React from 'react'
+import {ApplyEasingFunction} from '../components/apply-easing-function'
 import {Button} from '../components/button'
 import {CurveEditor} from '../components/curve-editor'
 import {Input} from '../components/input'
@@ -143,6 +144,10 @@ export function Curve({paletteId = '', curveId = ''}: RouteComponentProps<{palet
             </Button>
           </VStack>
         </SidebarPanel>
+        <Separator />
+        <ApplyEasingFunction
+          onApply={easingFunction => send({type: 'APPLY_EASING_FUNCTION', paletteId, curveId, easingFunction})}
+        />
         <Separator />
         <SidebarPanel title="Values">
           <VStack spacing={16}>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,3 +41,7 @@ export function getRange(type: Curve['type']) {
 export function getContrastScore(contrast: number) {
   return contrast < 3 ? 'Fail' : contrast < 4.5 ? 'AA Large' : contrast < 7 ? 'AA' : 'AAA'
 }
+
+export function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,6 +3265,11 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
 
+bezier-easing@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/bezier-easing/-/bezier-easing-2.1.0.tgz#c04dfe8b926d6ecaca1813d69ff179b7c2025d86"
+  integrity sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==
+
 bfj@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-7.0.2.tgz#1988ce76f3add9ac2913fd8ba47aad9e651bfbb2"


### PR DESCRIPTION
This allows you to apply a bezier easing function any shared curves, as discussed in #16. The endpoints of the existing curve are preserved, and the inner values are fit to the chosen curve.

![](https://user-images.githubusercontent.com/1724000/175399305-cb4092ee-6591-48b2-bfdd-6fe2d0409d06.png)

