### PR TITLE
Add error message when import scale with empty array

### DIFF
--- a/src/components/import-scales.tsx
+++ b/src/components/import-scales.tsx
@@ -37,7 +37,7 @@ export function ImportScales({onImport}: ImportScalesProps) {
         const scaleArray = isArray(scale) ? scale : [scale]
 
         if (scaleArray.length === 0) {
-          throw new Error(`Please, provide at least one color for ${name} scale`)
+          throw new Error(`Please provide at least one color for ${name} scale`)
         }
 
         return {id, name, colors: scaleArray.map(hexToColor), curves: {}}

--- a/src/components/import-scales.tsx
+++ b/src/components/import-scales.tsx
@@ -35,6 +35,11 @@ export function ImportScales({onImport}: ImportScalesProps) {
       const scales: Scale[] = Object.entries(parsedCode).map(([name, scale]) => {
         const id = uniqueId()
         const scaleArray = isArray(scale) ? scale : [scale]
+
+        if (scaleArray.length === 0) {
+          throw new Error(`Please, provide at least one color for ${name} scale`)
+        }
+
         return {id, name, colors: scaleArray.map(hexToColor), curves: {}}
       })
 


### PR DESCRIPTION
This PR fixes the issue #45 when we import scale with empty array.

The idea of this fix is to add an error message `Please, provide at least one color for ${keyName} scale` when user provides a schema with an empty array for scales.

Here is the example of this error 😊 

<img width="700" alt="CleanShot 2022-06-26 at 23 43 33@2x" src="https://user-images.githubusercontent.com/17102399/175833134-bc8d2e17-8456-4709-a019-aa4195a3708b.png">
